### PR TITLE
prevent dead breakpoint

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,6 @@
 
 export const breakpoints = {
-  xs: '(max-width: 24em)',
+  xs: '(min-width: 24em)',
   sm: '(min-width: 40em)',
   md: '(min-width: 52em)',
   lg: '(min-width: 64em)',


### PR DESCRIPTION
max to min-width creates a “dead” area with now breakpoint.